### PR TITLE
Add a build dependency to dune

### DIFF
--- a/async_graphics.opam
+++ b/async_graphics.opam
@@ -13,6 +13,7 @@ tags: [
   "graphics"
 ]
 depends: [
+  "dune" {build}
   "graphics"
   "async" {>= "v0.9"}
   "async_unix" {>= "v0.12"}


### PR DESCRIPTION
The opam file was lacking a dependency to dune.

If that's fine by you I'll also update `opam-repository`!

